### PR TITLE
Fixes module identification name in code

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "redux-wpapi",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Wordpress integration Redux middleware based on node-wpapi.",
   "main": "lib/index.js",
   "files": [

--- a/src/ReduxWPAPI.js
+++ b/src/ReduxWPAPI.js
@@ -37,7 +37,7 @@ const initialReducerState = Immutable.fromJS({
   entitiesIndexes: {},
 });
 
-export default class ReduxWP {
+export default class ReduxWPAPI {
   static displayName = '[REDUX-WP-API]';
 
   static defaultSettings = {
@@ -160,14 +160,14 @@ export default class ReduxWP {
   indexers = {}
 
   constructor(settings) {
-    this.settings = defaultsDeep({}, settings, ReduxWP.defaultSettings);
+    this.settings = defaultsDeep({}, settings, ReduxWPAPI.defaultSettings);
 
     if (!this.settings.api) {
-      throw new Error(`${ReduxWP.displayName}: 'api client must be provided`);
+      throw new Error(`${ReduxWPAPI.displayName}: 'api client must be provided`);
     }
 
     this.settings.customCacheIndexes = {
-      ...ReduxWP.defaultSettings, // reinforces demandatory indexes besides id
+      ...ReduxWPAPI.defaultSettings, // reinforces demandatory indexes besides id
       ...this.settings.customCacheIndexes,
     };
   }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -9,7 +9,7 @@ var config = {
     ],
   },
   output: {
-    library: 'ReduxWP',
+    library: 'ReduxWPAPI',
     libraryTarget: 'umd',
   },
   plugins: [


### PR DESCRIPTION
While renaming the modules before the launch, some old references have been left in the code.