### PR TITLE
selectRequest, fix for issue #12 and #14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ Some guidelines in reading this document:
   * **[BC]** - Ommits `localResources`, now that a denormalization methods exists.
   * Exposes `selectRequestRaw`, so a request might be selected without denormalization step
   * Fix [#12](https://github.com/log-oscon/redux-wpapi/issues/12) – Promise returned from middleware dispatch was overlaping responses with same name
-  * Fix [#14](https://github.com/log-oscon/redux-wpapi/issues/14) - lastUpdatedCache should be used as Symbol for preventing collisions, now been tested
+  * Fix [#14](https://github.com/log-oscon/redux-wpapi/issues/14) - lastCacheUpdate should be used as Symbol for preventing collisions, now been tested
 
 ## 1.1.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,9 @@ Some guidelines in reading this document:
 ## [new release]
 * Fix [#15](https://github.com/log-oscon/redux-wpapi/issues/15) - Support for register dashed-routes as camelCase ([#16](https://github.com/log-oscon/redux-wpapi/pull/16))
 * TTL (Time-to-live) now can be overriden by each request. ([#17](https://github.com/log-oscon/redux-wpapi/pull/17))
-* Fix [#12](https://github.com/log-oscon/redux-wpapi/issues/12) – Promise returned from middleware dispatch was overlaping responses with same name.
-* **[BC]** `selectQuery` renamed to `selectRequest` and now also accepts `{ cacheID, page }` for selecting Requests. ([#13](https://github.com/log-oscon/redux-wpapi/pull/13))
+* [#13](https://github.com/log-oscon/redux-wpapi/pull/13)
+  * **[BC]** - `selectQuery` renamed to `selectRequest` and now also accepts `{ cacheID, page }` for selecting Requests.
+  * Fix [#12](https://github.com/log-oscon/redux-wpapi/issues/12) – Promise returned from middleware dispatch was overlaping responses with same name.
 
 ## 1.1.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,8 @@ Some guidelines in reading this document:
 ## [new release]
 * Fix [#15](https://github.com/log-oscon/redux-wpapi/issues/15) - Support for register dashed-routes as camelCase ([#16](https://github.com/log-oscon/redux-wpapi/pull/16))
 * TTL (Time-to-live) now can be overriden by each request. ([#17](https://github.com/log-oscon/redux-wpapi/pull/17))
-* `selectQuery` renamed to `selectRequest` and now also accepts `{ cacheID, page }` for selecting Requests
+* **[BC]** `selectQuery` renamed to `selectRequest` and now also accepts `{ cacheID, page }` for selecting Requests.
+* Fix the Promise return from middleware dispatch ([#12](https://github.com/log-oscon/redux-wpapi/issues/12))
 
 ## 1.1.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,9 +14,11 @@ Some guidelines in reading this document:
 * Fix [#15](https://github.com/log-oscon/redux-wpapi/issues/15) - Support for register dashed-routes as camelCase ([#16](https://github.com/log-oscon/redux-wpapi/pull/16))
 * TTL (Time-to-live) now can be overriden by each request. ([#17](https://github.com/log-oscon/redux-wpapi/pull/17))
 * [#13](https://github.com/log-oscon/redux-wpapi/pull/13)
-  * **[BC]** - `selectQuery` renamed to `selectRequest` and now also accepts `{ cacheID, page }` for selecting Requests.
-  * Fix [#12](https://github.com/log-oscon/redux-wpapi/issues/12) – Promise returned from middleware dispatch was overlaping responses with same name.
-  * Fix [#14](https://github.com/log-oscon/redux-wpapi/issues/14) - lastUpdatedCache should be used as Symbol for preventing collisions, now been tested.
+  * **[BC]** - `selectQuery` renamed to `selectRequest` and now also accepts `{ cacheID, page }` for selecting Requests
+  * **[BC]** - Ommits `localResources`, now that a denormalization methods exists.
+  * Exposes `selectRequestRaw`, so a request might be selected without denormalization step
+  * Fix [#12](https://github.com/log-oscon/redux-wpapi/issues/12) – Promise returned from middleware dispatch was overlaping responses with same name
+  * Fix [#14](https://github.com/log-oscon/redux-wpapi/issues/14) - lastUpdatedCache should be used as Symbol for preventing collisions, now been tested
 
 ## 1.1.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Some guidelines in reading this document:
 * [#13](https://github.com/log-oscon/redux-wpapi/pull/13)
   * **[BC]** - `selectQuery` renamed to `selectRequest` and now also accepts `{ cacheID, page }` for selecting Requests.
   * Fix [#12](https://github.com/log-oscon/redux-wpapi/issues/12) – Promise returned from middleware dispatch was overlaping responses with same name.
+  * Fix [#14](https://github.com/log-oscon/redux-wpapi/issues/14) - lastUpdatedCache should be used as Symbol for preventing collisions, now been tested.
 
 ## 1.1.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ Some guidelines in reading this document:
 ## [new release]
 * Fix [#15](https://github.com/log-oscon/redux-wpapi/issues/15) - Support for register dashed-routes as camelCase ([#16](https://github.com/log-oscon/redux-wpapi/pull/16))
 * TTL (Time-to-live) now can be overriden by each request. ([#17](https://github.com/log-oscon/redux-wpapi/pull/17))
-* Fixes [#12](https://github.com/log-oscon/redux-wpapi/issues/12) – Promise returned from middleware dispatch was overlaping responses with same name.
+* Fix [#12](https://github.com/log-oscon/redux-wpapi/issues/12) – Promise returned from middleware dispatch was overlaping responses with same name.
 * **[BC]** `selectQuery` renamed to `selectRequest` and now also accepts `{ cacheID, page }` for selecting Requests. ([#13](https://github.com/log-oscon/redux-wpapi/pull/13))
 
 ## 1.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Some guidelines in reading this document:
 ## [new release]
 * Fix [#15](https://github.com/log-oscon/redux-wpapi/issues/15) - Support for register dashed-routes as camelCase ([#16](https://github.com/log-oscon/redux-wpapi/pull/16))
 * TTL (Time-to-live) now can be overriden by each request. ([#17](https://github.com/log-oscon/redux-wpapi/pull/17))
+* `selectQuery` renamed to `selectRequest` and now also accepts `{ cacheID, page }` for selecting Requests
 
 ## 1.1.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,8 @@ Some guidelines in reading this document:
 ## [new release]
 * Fix [#15](https://github.com/log-oscon/redux-wpapi/issues/15) - Support for register dashed-routes as camelCase ([#16](https://github.com/log-oscon/redux-wpapi/pull/16))
 * TTL (Time-to-live) now can be overriden by each request. ([#17](https://github.com/log-oscon/redux-wpapi/pull/17))
-* **[BC]** `selectQuery` renamed to `selectRequest` and now also accepts `{ cacheID, page }` for selecting Requests.
-* Fix the Promise return from middleware dispatch ([#12](https://github.com/log-oscon/redux-wpapi/issues/12))
+* Fixes [#12](https://github.com/log-oscon/redux-wpapi/issues/12) – Promise returned from middleware dispatch was overlaping responses with same name.
+* **[BC]** `selectQuery` renamed to `selectRequest` and now also accepts `{ cacheID, page }` for selecting Requests. ([#13](https://github.com/log-oscon/redux-wpapi/pull/13))
 
 ## 1.1.0
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ const store = createStore(
 ## Usage
 ```js
 import React from 'react';
-import { wp, selectQuery, ResponseStatus } from 'redux-wpapi';
+import { wp, selectRequest, ResponseStatus } from 'redux-wpapi';
 import { connect } from 'react-redux';
 
 export class HomePage extends React.Component {
@@ -74,7 +74,7 @@ export class HomePage extends React.Component {
 }
 
 export default connect({
-  request: selectQuery('HomePagePosts'),
+  request: selectRequest('HomePagePosts'),
 }, { callAPI })(HomePage);
 ```
 

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "eslint": "^3.4.0",
     "eslint-config-airbnb": "^10.0.1",
     "eslint-plugin-babel": "^3.3.0",
-    "eslint-plugin-import": "^1.14.0",
+    "eslint-plugin-import": "^1.16.0",
     "eslint-plugin-jsx-a11y": "^2.2.1",
     "eslint-plugin-react": "^6.2.0",
     "expect": "^1.20.2",

--- a/src/ReduxWPAPI.js
+++ b/src/ReduxWPAPI.js
@@ -8,7 +8,7 @@ import find from 'lodash/find';
 import Immutable from 'immutable';
 import isArray from 'lodash/isArray';
 import isUndefined from 'lodash/isUndefined';
-import { selectQuery } from './selectors';
+import { selectRequest } from './selectors';
 import WPAPIAdapter from './adapters/wpapi';
 import { lastCacheUpdate as lastCacheUpdateSymbol } from './symbols';
 
@@ -117,7 +117,10 @@ export default class ReduxWPAPI {
 
         if (Date.now() - lastCacheUpdate < ttl) {
           return Promise.resolve(
-            selectQuery(meta.name)(store.getState())
+            selectRequest({
+              cacheID: payload.cacheID,
+              page: payload.page,
+            })(store.getState())
           );
         }
       }
@@ -146,7 +149,16 @@ export default class ReduxWPAPI {
             meta: { ...meta, responseAt: Date.now() },
           })
       )
-      .then(() => selectQuery(meta.name)(store.getState()))
+      .then(() => {
+        if (meta.operation === 'get') {
+          return selectRequest({
+            cacheID: payload.cacheID,
+            page: payload.page,
+          })(store.getState());
+        }
+
+        return selectRequest(meta.name)(store.getState());
+      })
     );
   }
 

--- a/src/ReduxWPAPI.js
+++ b/src/ReduxWPAPI.js
@@ -234,7 +234,7 @@ export default class ReduxWPAPI {
         }
 
         const data = [];
-        const additionalData = { lastCacheUpdate: requestState.responseAt };
+        const additionalData = { [lastCacheUpdateSymbol]: requestState.responseAt };
 
         body.forEach(resource => {
           newState = this.indexResource(newState, aggregator, resource, additionalData);

--- a/src/index.js
+++ b/src/index.js
@@ -4,4 +4,4 @@ export default ReduxWPAPI;
 export * as RequestStatus from './constants/requestStatus';
 export callAPI from './actions/callAPI';
 export * as Symbols from './symbols';
-export { selectQuery, withDenormalize } from './selectors';
+export { selectQuery, selectRequest, withDenormalize } from './selectors';

--- a/src/selectors.js
+++ b/src/selectors.js
@@ -1,12 +1,14 @@
 import isFunction from 'lodash/isFunction';
 import { createSelector } from 'reselect';
 import isString from 'lodash/isString';
-import constant from 'lodash/constant';
 import Immutable from 'immutable';
 
 import { pending } from './constants/requestStatus';
 import { mapDeep } from './helpers';
 import { id as idSymbol } from './symbols';
+
+const requestsByQuery = state => state.wp.getIn(['requestsByQuery']);
+const localResources = state => state.wp.getIn(['resources']);
 
 export const denormalize = (resources, id, memoized = {}) => {
   /* eslint-disable no-param-reassign, no-underscore-dangle */
@@ -28,8 +30,6 @@ export const denormalize = (resources, id, memoized = {}) => {
   return memoized[id];
 };
 
-export const localResources = state => state.wp.getIn(['resources']);
-
 export const withDenormalize = thunk =>
   createSelector(
     localResources,
@@ -44,76 +44,112 @@ export const withDenormalize = thunk =>
     }
   );
 
-export const selectRequest = (requestData) => {
-  let requestIDSelector;
-  if (isString(requestData)) {
-    requestIDSelector = state => state.wp.getIn(['requestsByName', requestData]);
-  } else if (requestData.name) {
-    requestIDSelector = state =>
-      state.wp.getIn(['requestsByName', requestData.name]).merge(requestData);
-  } else {
-    if (!requestData.cacheID) {
-      throw new Error(
-        '\'cacheId\' or \'name\' must be provided for selectRequest'
-      );
-    }
 
-    requestIDSelector = constant(new Immutable.Map({
-      page: 1,
-      ...requestData,
-    }));
+/**
+ * Adds pagination when available
+ */
+function formatRequestRaw(request, cache) {
+  if (!request) return { status: pending, data: false, error: false };
+
+  let requestFormatted = request;
+  const cacheID = request.get('cacheID');
+  const page = request.get('page');
+
+  if (cacheID) {
+    requestFormatted = request
+    .merge(cache.getIn([cacheID, page]))
+    .merge(cache.getIn([cacheID, 'pagination']));
   }
 
-  return createSelector(
-    createSelector(
-      requestIDSelector,
-      state => state.wp.getIn(['requestsByQuery']),
-      (currentRequest, cache) => {
-        if (!currentRequest) return false;
+  requestFormatted = requestFormatted.toJSON();
 
-        const cacheID = currentRequest.get('cacheID');
-        const page = currentRequest.get('page');
+  if (!requestFormatted.data) {
+    return { data: false, error: false, ...requestFormatted };
+  }
 
-        if (cacheID) {
-          return currentRequest
-          .merge(cache.getIn([cacheID, page]))
-          .merge(cache.getIn([cacheID, 'pagination']));
-        }
+  return requestFormatted;
+}
 
-        return currentRequest;
-      }
-    ),
+
+/**
+ * Creates a selector without denormalization to resolve to a Request
+ *
+ * Creates a selector to resolve to a Request based on requestData, which might be either its name
+ * or a cacheID and page. It doesn't do any denormalization, so data contains local ids.
+ *
+ * @param   {String|Object} requestData If string, the name of the request, if Object, the cacheID
+ *                                      and the page for that request.
+ *
+ * @returns {Function}                  Selector to pick from state the request.
+ */
+export const selectRequestRaw = (requestData) => {
+  if (!requestData) {
+    throw new Error(
+      '\'requestData\' must either be the request name or a object with its cacheID and page'
+    );
+  }
+
+  if (isString(requestData)) {
+    return createSelector(
+      state => state.wp.getIn(['requestsByName', requestData]),
+      requestsByQuery,
+      formatRequestRaw
+    );
+  }
+
+  if (requestData.name) {
+    return createSelector(
+      state => state.wp.getIn(['requestsByName', requestData.name]).merge(requestData),
+      requestsByQuery,
+      formatRequestRaw
+    );
+  }
+
+  if (!requestData.cacheID) {
+    throw new Error(
+      '\'cacheId\' or \'name\' must be provided for selectRequest'
+    );
+  }
+
+  const request = new Immutable.Map({
+    page: 1,
+    data: false,
+    ...requestData,
+  });
+
+  return (...args) => formatRequestRaw(request, requestsByQuery(...args));
+};
+
+/**
+ * creates selector for a request
+ *
+ * Creates a selector by its name or by its cacheID and page.
+ *
+ * @param   {String|Object} queryID If string, the name of the request, if Object, the cacheID
+ *                                  and the page for that request.
+ * @returns {Function}              Selector which accepts the app state and returns the request
+ */
+export const selectRequest = (requestData) =>
+  createSelector(
+    selectRequestRaw(requestData),
     localResources,
-    (request, resources) => {
-      if (!request) {
-        return {
-          status: pending,
-          error: false,
-          data: false,
-        };
-      }
-
-      if (!request.get('data')) {
-        return {
-          data: false,
-          error: false,
-          ...request.toJSON(),
-        };
+    (requestRaw, resources) => {
+      if (!requestRaw.data) {
+        return requestRaw;
       }
 
       const memo = {};
-      let data = request.get('data');
-      if (data.toJSON) {
-        data = data.toJSON();
-      }
-
-      return request.set(
-        'data', data.map(id => denormalize(resources, id, memo))
-      ).toJSON();
+      return {
+        ...requestRaw,
+        data: requestRaw.data.map(id => denormalize(resources, id, memo)),
+      };
     }
   );
-};
 
+
+/**
+ * @deprecated use selectRequest instead
+ */
 export const selectQuery = (name) => {
   // eslint-disable-next-line no-console
   console.warn('Deprecation warning: `selectQuery` was renamed to `selectRequest`');

--- a/test/middleware.spec.js
+++ b/test/middleware.spec.js
@@ -220,7 +220,7 @@ describe('Middleware', () => {
     });
   });
 
-  it('should return a promise that reject to selectRequest result', () => {
+  it('should return a promise that rejects to selectRequest result', () => {
     const { middleware } = new ReduxWPAPI({
       adapter: createFakeAdapter(unsuccessfulCollectionRequest, {
         sendRequest: () => Promise.reject(unsuccessfulCollectionRequest.error),

--- a/test/middleware.spec.js
+++ b/test/middleware.spec.js
@@ -193,9 +193,9 @@ describe('Middleware', () => {
     });
   });
 
-  it('should return a promise that resolves to selectQuery result', () => {
+  it('should return a promise that resolves to selectRequest result', () => {
     const { middleware } = new ReduxWPAPI({
-      adapter: createFakeAdapter(successfulCollectionRequest),
+      adapter: createFakeAdapter(successfulQueryBySlug),
     });
 
     const dispatched = [];
@@ -204,7 +204,7 @@ describe('Middleware', () => {
       dispatched.push(dispatch);
       store.state = { wp: successfulQueryBySlugState };
     };
-    const action = createCallAPIActionFrom(successfulCollectionRequest);
+    const action = createCallAPIActionFrom(successfulQueryBySlug);
     const result = middleware(store)(fakeNext)(action);
     expect(result).toBeA(Promise);
 
@@ -220,7 +220,7 @@ describe('Middleware', () => {
     });
   });
 
-  it('should return a promise that reject to selectQuery result', () => {
+  it('should return a promise that reject to selectRequest result', () => {
     const { middleware } = new ReduxWPAPI({
       adapter: createFakeAdapter(unsuccessfulCollectionRequest, {
         sendRequest: () => Promise.reject(unsuccessfulCollectionRequest.error),

--- a/test/reducer.spec.js
+++ b/test/reducer.spec.js
@@ -4,6 +4,7 @@ import Immutable from 'immutable';
 import ReduxWPAPI from '../src/index.js';
 import { pending, resolved, rejected } from '../src/constants/requestStatus';
 
+import * as Symbols from '../src/symbols';
 import collectionRequest from './mocks/actions/collectionRequest';
 import modifyingRequest from './mocks/actions/modifyingRequest';
 import successfulCollectionRequest from './mocks/actions/successfulCollectionRequest';
@@ -133,6 +134,9 @@ describe('Reducer', () => {
 
       expect(data).toBeAn(Array);
       expect(data.length).toBe(2);
+      expect(state.getIn(['resources', data[0]])).toContain({
+        [Symbols.lastCacheUpdate]: successfulCollectionRequest.meta.responseAt,
+      }, 'lastCacheUpdate should be updated');
     });
 
     it('should keep local ids instead objects in data, by query\'s cacheID', () => {
@@ -170,6 +174,7 @@ describe('Reducer', () => {
       const [id] = queryState.getIn([1, 'data']);
       const resource = state.getIn(['resources', id]);
       expect(resource).toContain({
+        [Symbols.lastCacheUpdate]: successfulQueryBySlug.meta.responseAt,
         link: successfulQueryBySlug.payload.response[0].link,
       });
     });

--- a/test/selector.spec.js
+++ b/test/selector.spec.js
@@ -17,6 +17,16 @@ describe('Selector selectQuery', () => {
 });
 
 describe('Selector selectRequestRaw', () => {
+  it('should throw when Request is not Identifiable', () => {
+    expect(() => {
+      selectRequestRaw();
+    }).toThrow();
+
+    expect(() => {
+      selectRequestRaw({});
+    }).toThrow();
+  });
+
   it('should return a Request for empty state', () => {
     const state = { wp: initialReducerState };
     expect(selectRequestRaw('test')(state))


### PR DESCRIPTION
* This PR renames `selectQuery` to `selectRequest` because it also applies to a modifying operation.
* Fixes the issue ([#12](https://github.com/log-oscon/redux-wpapi/issues/12)), which was causing response overlapping for a given request name.
* Fixes the issue ([#14](https://github.com/log-oscon/redux-wpapi/issues/14)), lastUpdatedCache mistakenly used statically when expected to be a Symbol