### PR TITLE
Support for dashed-routes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ Some guidelines in reading this document:
 * Being that these are the early days of the repository, we have some code changes that were added directly and without much detail, for these we have a link to the commit instead of the PR.
 * Annotations starting with **[BC]** indicates breaking change.
 
+## [new release]
+* Fix [#15](https://github.com/log-oscon/redux-wpapi/issues/15) - Support for register dashed-routes as camelCase ([#16](https://github.com/log-oscon/redux-wpapi/pull/16))
+
 ## 1.1.0
 
 * Expose a denormalization mechanism so consumer can transform local ids into resources denormalized ([#11](https://github.com/log-oscon/redux-wpapi/pull/11))

--- a/src/adapters/wpapi.js
+++ b/src/adapters/wpapi.js
@@ -2,6 +2,7 @@ import find from 'lodash/find';
 import findKey from 'lodash/findKey';
 import reduce from 'lodash/reduce';
 import capitalize from 'lodash/capitalize';
+import camelCase from 'lodash/camelCase';
 
 /**
  * This adapter connects `node-wpapi` to `redux-wpapi`, abstracting any
@@ -218,7 +219,12 @@ export default class WPAPIAdapter {
     // Skips namespace, takes fragments and preserves only static parts
     uri = uri.replace(`${namespace}/`, '');
     const fragments = uri.split('/');
-    const [resource] = fragments;
+    const resource = camelCase(fragments[0]);
+
+    if (!this.api[resource]) {
+      throw new Error(`Unregistered route, expected '${resource}' to resolve to '${url}'`);
+    }
+
     const query = this.api[resource]();
     let aggregator = resource;
 


### PR DESCRIPTION
Fix for https://github.com/log-oscon/redux-wpapi/issues/15 . Current implementation required any custom route to be registed previously, but so far, dashed routes should be registered as `dashed-routes` in the api, as in:

```
api['my-dashed-route'] = api.registerRouter('wp/v2', '/my-dashed-route/(?P<id>)');
```

This PR adds the possibility to use camelCase form:

```
api.myDashedRoute = api.registerRouter('wp/v2', '/my-dashed-route/(?P<id>)');
```
