### PR TITLE
Aggregator decided per resource now

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ Some guidelines in reading this document:
 * Being that these are the early days of the repository, we have some code changes that were added directly and without much detail, for these we have a link to the commit instead of the PR.
 * Annotations starting with **[BC]** indicates breaking change.
 
+## [new release]
+* ([#22](https://github.com/log-oscon/redux-wpapi/pull/22))
+    * Adapter's `getAggregator` is now applied per resource and has `additionalData` in order decide, which might be either the query of the request or the resource itself.
+    * `getAggregator` setting is now available, so consumer might also decide per resource. As its third param, the `suggestedAggregator` is supplied contain the adapter's `getAggregator` return.
+
 ## 1.2.1
 * ([#21](https://github.com/log-oscon/redux-wpapi/pull/21))
     * Mark embedded resource as `partial` until they are fetched individually (closes [#20](https://github.com/log-oscon/redux-wpapi/issues/20))

--- a/src/ReduxWPAPI.js
+++ b/src/ReduxWPAPI.js
@@ -51,9 +51,11 @@ export default class ReduxWPAPI {
      * be associated with. An aggregator is a set containing resources indexed by its ids and by the
      * its custom indexers.
      *
-     * @param  {String}      url          URL from which the aggregator will be infered
-     * @return {String|null} aggregatorID String to which the resource will be associated
-     *                                    with or null, if resources musn't be indexed
+     * @param  {String}      url                 URL from which the aggregator will be infered
+     * @param  {Object|null} additionalData      Available data about the expected resource
+     * @param  {String}      suggestedAggregator Suggestion given by the adapter
+     * @return {String|null} aggregatorID        String to which the resource will be associated
+     *                                           with or null, if resources musn't be indexed
      */
     getAggregator: nthArg(2),
     timeout: 30000,

--- a/src/ReduxWPAPI.js
+++ b/src/ReduxWPAPI.js
@@ -43,6 +43,7 @@ export default class ReduxWPAPI {
 
   static defaultSettings = {
     transformResource: nthArg(0),
+    getAggregator: nthArg(2),
     timeout: 30000,
     ttl: 60000,
   }
@@ -69,7 +70,7 @@ export default class ReduxWPAPI {
     const request = this.adapter.buildRequest(action.payload);
     const meta = {
       name: action.payload.name,
-      aggregator: this.adapter.getAggregator(this.adapter.getUrl(request)),
+      url: this.adapter.getUrl(request),
       operation: this.adapter.getOperation(request),
       requestAt: Date.now(),
     };
@@ -90,7 +91,12 @@ export default class ReduxWPAPI {
 
       const state = store.getState().wp;
       const indexes = this.adapter.getIndexes(request);
-      const resourceLocalID = this.getResourceLocalID(state, meta.aggregator, indexes);
+      const aggregator = this.settings.getAggregator(
+        meta.url,
+        indexes,
+        this.adapter.getAggregator(meta.url)
+      );
+      const resourceLocalID = this.getResourceLocalID(state, aggregator, indexes);
 
       payload.cacheID = this.adapter.generateCacheID(request);
       payload.page = parseInt(this.adapter.getRequestedPage(request) || 1, 10);
@@ -231,7 +237,7 @@ export default class ReduxWPAPI {
       }
       case REDUX_WP_API_SUCCESS: {
         let newState = state;
-        const { payload, meta: { name, aggregator, requestAt, responseAt } } = action;
+        const { payload, meta: { name, url, requestAt, responseAt } } = action;
         const { cacheID, page, response } = payload;
         let body = response;
 
@@ -252,7 +258,7 @@ export default class ReduxWPAPI {
         };
 
         body.forEach(resource => {
-          newState = this.indexResource(newState, aggregator, resource, additionalData, id => {
+          newState = this.indexResource(newState, url, resource, additionalData, id => {
             data.push(id);
           });
         });
@@ -311,9 +317,14 @@ export default class ReduxWPAPI {
     return state.getIn(['resourcesIndexes', aggregator, indexBy, resource[indexBy].toString()]);
   }
 
-  indexResource(state, aggregator, resource, meta, onIndex = noop) {
+  indexResource(state, url, resource, meta, onIndex = noop) {
     let newState = state;
     let _embedded;
+    const aggregator = this.settings.getAggregator(
+      url,
+      resource,
+      this.adapter.getAggregator(url, resource)
+    );
     const curies = (resource._links || {}).curies;
     const _links = this.resolveAliases(resource._links, curies) || {};
     delete _links.curies;
@@ -331,16 +342,13 @@ export default class ReduxWPAPI {
       const embeddedMeta = { ...meta, [partialSymbol]: true };
       forEach(alisedEmbedded, (embeddable, relName) => {
         forEach(_links[relName], (link, index) => {
-          const embeddedAggregator = this.adapter.getAggregator(link.href);
-          if (!embeddedAggregator) return;
-
           let toEmbed = alisedEmbedded[relName][index];
           toEmbed = (isArray(toEmbed) ? toEmbed : [toEmbed]).reduce((collection, toBeEmbedded) => {
             if (toBeEmbedded.code === 'rest_no_route') return collection;
 
             newState = this.indexResource(
               newState,
-              embeddedAggregator,
+              link.href,
               toBeEmbedded,
               embeddedMeta,
               id => collection.push(id)

--- a/src/ReduxWPAPI.js
+++ b/src/ReduxWPAPI.js
@@ -43,6 +43,18 @@ export default class ReduxWPAPI {
 
   static defaultSettings = {
     transformResource: nthArg(0),
+
+    /**
+     * Get aggregator for URL
+     *
+     * Infers the aggregator identifier of a given URL to which all resulting resources are going to
+     * be associated with. An aggregator is a set containing resources indexed by its ids and by the
+     * its custom indexers.
+     *
+     * @param  {String}      url          URL from which the aggregator will be infered
+     * @return {String|null} aggregatorID String to which the resource will be associated
+     *                                    with or null, if resources musn't be indexed
+     */
     getAggregator: nthArg(2),
     timeout: 30000,
     ttl: 60000,

--- a/src/adapters/wpapi.js
+++ b/src/adapters/wpapi.js
@@ -194,7 +194,7 @@ export default class WPAPIAdapter {
    * @return {Object}         The Request URL
    */
   getUrl({ wpRequest }) {
-    return wpRequest._renderURI();
+    return wpRequest.toString();
   }
 
   /**

--- a/src/adapters/wpapi.js
+++ b/src/adapters/wpapi.js
@@ -207,9 +207,10 @@ export default class WPAPIAdapter {
    * An aggregator is a set containing resources indexed by its ids and by the
    * its custom indexers.
    *
-   * @param  {String}      url          URL from which the aggregator will be infered
-   * @return {String|null} aggregatorID String to which all URL direct resources will be associated
-   *                                    with or null, if resources musn't be indexed
+   * @param  {String}      url            URL from which the aggregator will be infered
+   * @param  {Object|null} additionalData Available data about the expected resource
+   * @return {String|null} aggregatorID   String to which all URL direct resources will be
+   *                                      associated with or null, if resources musn't be indexed
    */
   getAggregator(url) {
     let uri = url.replace(this.api._options.endpoint, '').replace(/\?.*$/, '');

--- a/src/adapters/wpapi.js
+++ b/src/adapters/wpapi.js
@@ -200,8 +200,11 @@ export default class WPAPIAdapter {
   /**
    * Get aggregator for URL
    *
-   * Infers the aggregator identifier of a given URL to which all resulting resources are going to
-   * be associated with. An aggregator is a set containing resources indexed by its ids and by the
+   * Infers the aggregator identifier of a given URL to which a resulting resource will be
+   * associated with. `additionalData` is available so the decision might also be based on the query
+   * or on the own resource.
+   *
+   * An aggregator is a set containing resources indexed by its ids and by the
    * its custom indexers.
    *
    * @param  {String}      url          URL from which the aggregator will be infered

--- a/test/mocks/actions/cacheHitCollection.js
+++ b/test/mocks/actions/cacheHitCollection.js
@@ -10,7 +10,7 @@ export default {
   },
   meta: {
     name: 'test',
-    aggregator: 'any',
+    url: 'http://wordpress.dev/wp-json/namespace/any',
     operation: 'get',
     requestAt: Date.now(),
   },

--- a/test/mocks/actions/cacheHitSingle.js
+++ b/test/mocks/actions/cacheHitSingle.js
@@ -10,7 +10,7 @@ export default {
   },
   meta: {
     name: 'test',
-    aggregator: 'any',
+    url: 'http://wordpress.dev/wp-json/namespace/any',
     operation: 'get',
     requestAt: Date.now(),
   },

--- a/test/mocks/actions/collectionRequest.js
+++ b/test/mocks/actions/collectionRequest.js
@@ -8,7 +8,7 @@ export default {
   },
   meta: {
     name: 'test',
-    aggregator: 'any',
+    url: 'http://wordpress.dev/wp-json/namespace/any',
     requestAt: Date.now(),
     operation: 'get',
   },

--- a/test/mocks/actions/modifyingRequest.js
+++ b/test/mocks/actions/modifyingRequest.js
@@ -7,7 +7,7 @@ export default {
     name: 'test',
     requestAt: Date.now(),
     // operation will be injected;
-    aggregator: 'any',
+    url: 'http://wordpress.dev/wp-json/namespace/any',
     params: { /* irrelant to this point */ },
   },
 };

--- a/test/mocks/actions/successfulAuthorRequest.js
+++ b/test/mocks/actions/successfulAuthorRequest.js
@@ -10,7 +10,7 @@ export default {
   },
   meta: {
     name: 'test',
-    aggregator: 'users',
+    url: 'http://wordpress.dev/wp-json/wp/v2/users',
     requestAt: Date.now(),
     responseAt: Date.now(),
     operation: 'get',

--- a/test/mocks/actions/successfulCollectionRequest.js
+++ b/test/mocks/actions/successfulCollectionRequest.js
@@ -10,7 +10,7 @@ export default {
   },
   meta: {
     name: 'test',
-    aggregator: 'any',
+    url: 'http://wordpress.dev/wp-json/namespace/any',
     requestAt: Date.now(),
     responseAt: Date.now(),
     operation: 'get',

--- a/test/mocks/actions/successfulOptionsRequest.js
+++ b/test/mocks/actions/successfulOptionsRequest.js
@@ -10,7 +10,7 @@ export default {
   },
   meta: {
     name: 'test',
-    aggregator: 'options',
+    url: 'http://wordpress.dev/wp-json/wp/v2/options',
     requestAt: Date.now(),
     responseAt: Date.now(),
     operation: 'get',

--- a/test/mocks/actions/successfulQueryBySlug.js
+++ b/test/mocks/actions/successfulQueryBySlug.js
@@ -10,7 +10,7 @@ export default {
   },
   meta: {
     name: 'test',
-    aggregator: 'any',
+    url: 'http://wordpress.dev/wp-json/namespace/any',
     requestAt: Date.now(),
     responseAt: Date.now(),
     operation: 'get',

--- a/test/mocks/actions/successfulSearchRequest.js
+++ b/test/mocks/actions/successfulSearchRequest.js
@@ -1,0 +1,18 @@
+import { REDUX_WP_API_SUCCESS } from '../../../src/constants/actions';
+import collectionResponse from '../data/collectionResponse';
+
+export default {
+  type: REDUX_WP_API_SUCCESS,
+  payload: {
+    cacheID: '/namespace/search',
+    page: 1,
+    response: collectionResponse,
+  },
+  meta: {
+    name: 'test',
+    url: 'http://wordpress.dev/wp-json/namespace/search',
+    requestAt: Date.now(),
+    responseAt: Date.now(),
+    operation: 'get',
+  },
+};

--- a/test/mocks/actions/unsuccessfulCollectionRequest.js
+++ b/test/mocks/actions/unsuccessfulCollectionRequest.js
@@ -9,7 +9,7 @@ export default {
   error: new Error('Network Failure'),
   meta: {
     name: 'test',
-    aggregator: 'any',
+    url: 'http://wordpress.dev/wp-json/namespace/any',
     requestAt: Date.now(),
     responseAt: Date.now(),
     operation: 'get',

--- a/test/mocks/actions/unsuccessfulModifyingRequest.js
+++ b/test/mocks/actions/unsuccessfulModifyingRequest.js
@@ -6,7 +6,7 @@ export default {
   error: new Error('Network Failure'),
   meta: {
     name: 'test',
-    aggregator: 'any',
+    url: 'http://wordpress.dev/wp-json/namespace/any',
     // operation will be injected;
     requestAt: Date.now(),
     responseAt: Date.now(),

--- a/test/mocks/createFakeAdapter.js
+++ b/test/mocks/createFakeAdapter.js
@@ -1,11 +1,11 @@
 export default (actionTarget, override) => {
   class Adapter {
-    getAggregator() { return actionTarget.meta.aggregator; }
+    getAggregator() { return actionTarget.meta.url.replace(/^.*?\/([^/]*?)(\?.*)?$/, '$1'); }
     getOperation() { return actionTarget.meta.operation; }
     generateCacheID() { return actionTarget.payload.cacheID; }
     getRequestedPage() { return actionTarget.payload.page; }
 
-    getUrl() { return ''; }
+    getUrl() { return actionTarget.meta.url; }
     getIndexes() { return {}; }
     buildRequest() { return {}; }
     sendRequest() { return Promise.resolve(actionTarget.payload.response); }

--- a/test/reducer.spec.js
+++ b/test/reducer.spec.js
@@ -10,6 +10,7 @@ import modifyingRequest from './mocks/actions/modifyingRequest';
 import successfulCollectionRequest from './mocks/actions/successfulCollectionRequest';
 import successfulQueryBySlug from './mocks/actions/successfulQueryBySlug';
 import successfulOptionsRequest from './mocks/actions/successfulOptionsRequest';
+import successfulSearchRequest from './mocks/actions/successfulSearchRequest';
 import unsuccessfulCollectionRequest from './mocks/actions/unsuccessfulCollectionRequest';
 import unsuccessfulModifyingRequest from './mocks/actions/unsuccessfulModifyingRequest';
 import cacheHitSingle from './mocks/actions/cacheHitSingle';
@@ -20,258 +21,334 @@ describe('Reducer', () => {
   const modifyingOperations = ['create', 'update', 'delete'];
   let reducer;
 
-  beforeEach(() => {
-    reducer = new ReduxWPAPI({
-      adapter: new AdapterMockForReducer(),
-      customCacheIndexes: {
-        any: 'slug',
-      },
-    }).reducer;
-  });
-
-  it('should have the right Immutable instances for its initial state', () => {
-    const initialState = reducer(undefined, {});
-    expect(initialState).toBeA(Immutable.Map);
-    expect(initialState.get('resources')).toBeA(Immutable.List);
-    expect(initialState.get('resourcesIndexes')).toBeA(Immutable.Map);
-    expect(initialState.get('requestsByQuery')).toBeA(Immutable.Map);
-    expect(initialState.get('requestsByName')).toBeA(Immutable.Map);
-  });
-
-  it('shouldnt change state for irrelant actions', () => {
-    const initialState = reducer(undefined, {});
-    expect(reducer(initialState, { type: 'NO-OP ACTION' }))
-    .toBe(initialState);
-  });
-
-  describe('`REDUX_WP_API_REQUEST` action', () => {
-    describe('operation GET', () => {
-      it('should keep request related data by query\'s cacheID', () => {
-        const state = reducer(undefined, collectionRequest);
-        const queryState = state.getIn(['requestsByQuery', collectionRequest.payload.cacheID]);
-        expect(queryState).toBeAn(Immutable.Map);
-        expect(queryState.get('pagination')).toNotBeAn(Immutable.Map);
-        expect(queryState.get(collectionRequest.payload.page)).toBeAn(Immutable.Map);
-        expect(queryState.get(collectionRequest.payload.page).toJSON())
-        .toEqual({
-          status: pending,
-          operation: collectionRequest.meta.operation,
-          requestAt: collectionRequest.meta.requestAt,
-        });
-
-        expect(queryState.getIn([collectionRequest.payload.page, 'data']))
-        .toBe(undefined, 'shouldnt touch data');
-      });
-
-      it('should keep by request name the enought data to reach query', () => {
-        const state = reducer(undefined, collectionRequest);
-        const nameState = state.getIn(['requestsByName', collectionRequest.meta.name]);
-
-        expect(nameState.get('page')).toBe(collectionRequest.payload.page);
-        expect(nameState.get('cacheID')).toBe(collectionRequest.payload.cacheID);
-      });
-
-      it('should keep previous data under query', () => {
-        const firstState = reducer(undefined, collectionRequest);
-        const secondState = reducer(firstState, successfulCollectionRequest);
-        const thirdState = reducer(secondState, {
-          ...collectionRequest,
-          meta: {
-            ...collectionRequest.meta,
-            // request renewed
-            requestAt: Date.now(),
-          },
-        });
-
-        expect(thirdState.getIn(['requestsByQuery', collectionRequest.payload.cacheID, 'data']))
-        .toBe(secondState.getIn(['requestsByQuery', collectionRequest.payload.cacheID, 'data']));
-      });
+  describe('with default getAggregator setting', () => {
+    beforeEach(() => {
+      reducer = new ReduxWPAPI({
+        adapter: new AdapterMockForReducer(),
+        customCacheIndexes: {
+          any: 'slug',
+        },
+      }).reducer;
     });
 
-    modifyingOperations
-    .forEach(type =>
-      describe(`on operation ${type.toUpperCase()}`, () => {
-        const request = { ...modifyingRequest, meta: { ...modifyingRequest.meta, type } };
-        it('should keep request related data by request name', () => {
-          const state = reducer(undefined, request);
-          const nameState = state.getIn(['requestsByName', request.meta.name]);
-          expect(nameState).toBeAn(Immutable.Map);
-          expect(nameState.toJSON())
+    it('should have the right Immutable instances for its initial state', () => {
+      const initialState = reducer(undefined, {});
+      expect(initialState).toBeA(Immutable.Map);
+      expect(initialState.get('resources')).toBeA(Immutable.List);
+      expect(initialState.get('resourcesIndexes')).toBeA(Immutable.Map);
+      expect(initialState.get('requestsByQuery')).toBeA(Immutable.Map);
+      expect(initialState.get('requestsByName')).toBeA(Immutable.Map);
+    });
+
+    it('shouldnt change state for irrelant actions', () => {
+      const initialState = reducer(undefined, {});
+      expect(reducer(initialState, { type: 'NO-OP ACTION' }))
+      .toBe(initialState);
+    });
+
+    describe('`REDUX_WP_API_REQUEST` action', () => {
+      describe('operation GET', () => {
+        it('should keep request related data by query\'s cacheID', () => {
+          const state = reducer(undefined, collectionRequest);
+          const queryState = state.getIn(['requestsByQuery', collectionRequest.payload.cacheID]);
+          expect(queryState).toBeAn(Immutable.Map);
+          expect(queryState.get('pagination')).toNotBeAn(Immutable.Map);
+          expect(queryState.get(collectionRequest.payload.page)).toBeAn(Immutable.Map);
+          expect(queryState.get(collectionRequest.payload.page).toJSON())
           .toEqual({
             status: pending,
-            operation: request.meta.operation,
-            requestAt: request.meta.requestAt,
-            data: false,
+            operation: collectionRequest.meta.operation,
+            requestAt: collectionRequest.meta.requestAt,
           });
+
+          expect(queryState.getIn([collectionRequest.payload.page, 'data']))
+          .toBe(undefined, 'shouldnt touch data');
         });
-      })
-    );
-  });
 
-  describe('`REDUX_WP_API_SUCCESS` action', () => {
-    it('should keep request related data by query\'s cacheID for GET operations', () => {
-      const state = reducer(undefined, successfulCollectionRequest);
-      const queryState = state.getIn([
-        'requestsByQuery',
-        successfulCollectionRequest.payload.cacheID,
-      ]);
+        it('should keep by request name the enought data to reach query', () => {
+          const state = reducer(undefined, collectionRequest);
+          const nameState = state.getIn(['requestsByName', collectionRequest.meta.name]);
 
-      expect(queryState).toBeAn(Immutable.Map);
-      expect(queryState.get('pagination'))
-      .toNotBeAn(Immutable.Map)
-      .toEqual({
-        total: 2,
-        totalPages: 1,
-      });
-      expect(queryState.get(successfulCollectionRequest.payload.page)).toBeAn(Immutable.Map);
+          expect(nameState.get('page')).toBe(collectionRequest.payload.page);
+          expect(nameState.get('cacheID')).toBe(collectionRequest.payload.cacheID);
+        });
 
-      const data = queryState.getIn([successfulCollectionRequest.payload.page, 'data']);
-      expect(queryState.get(successfulCollectionRequest.payload.page).toJSON())
-      .toInclude({
-        status: resolved,
-        error: false,
-        responseAt: successfulCollectionRequest.meta.responseAt,
+        it('should keep previous data under query', () => {
+          const firstState = reducer(undefined, collectionRequest);
+          const secondState = reducer(firstState, successfulCollectionRequest);
+          const thirdState = reducer(secondState, {
+            ...collectionRequest,
+            meta: {
+              ...collectionRequest.meta,
+              // request renewed
+              requestAt: Date.now(),
+            },
+          });
+
+          expect(thirdState.getIn(['requestsByQuery', collectionRequest.payload.cacheID, 'data']))
+          .toBe(secondState.getIn(['requestsByQuery', collectionRequest.payload.cacheID, 'data']));
+        });
       });
 
-      expect(data).toBeAn(Array);
-      expect(data.length).toBe(2);
-
-      const resource = state.getIn(['resources', data[0]]);
-      expect(resource[Symbols.lastCacheUpdate]).toBe(successfulCollectionRequest.meta.responseAt);
-      expect(resource[Symbols.partial]).toBe(false);
+      modifyingOperations
+      .forEach(type =>
+        describe(`on operation ${type.toUpperCase()}`, () => {
+          const request = { ...modifyingRequest, meta: { ...modifyingRequest.meta, type } };
+          it('should keep request related data by request name', () => {
+            const state = reducer(undefined, request);
+            const nameState = state.getIn(['requestsByName', request.meta.name]);
+            expect(nameState).toBeAn(Immutable.Map);
+            expect(nameState.toJSON())
+            .toEqual({
+              status: pending,
+              operation: request.meta.operation,
+              requestAt: request.meta.requestAt,
+              data: false,
+            });
+          });
+        })
+      );
     });
 
-    it('should keep local ids instead objects in data, by query\'s cacheID', () => {
-      const state = reducer(undefined, successfulCollectionRequest);
-      const queryState = state.getIn([
-        'requestsByQuery',
-        successfulCollectionRequest.payload.cacheID,
-      ]);
-      const data = queryState.getIn([successfulCollectionRequest.payload.page, 'data']);
+    describe('`REDUX_WP_API_SUCCESS` action', () => {
+      it('should keep request related data by query\'s cacheID for GET operations', () => {
+        const state = reducer(undefined, successfulCollectionRequest);
+        const queryState = state.getIn([
+          'requestsByQuery',
+          successfulCollectionRequest.payload.cacheID,
+        ]);
 
-      expect(data).toBeAn(Array);
-      expect(data.length).toBe(2);
-      expect(state.getIn(['resources', data[0]]).link)
-      .toBe(successfulCollectionRequest.payload.response[0].link);
+        expect(queryState).toBeAn(Immutable.Map);
+        expect(queryState.get('pagination'))
+        .toNotBeAn(Immutable.Map)
+        .toEqual({
+          total: 2,
+          totalPages: 1,
+        });
+        expect(queryState.get(successfulCollectionRequest.payload.page)).toBeAn(Immutable.Map);
 
-      expect(state.getIn(['resources', data[1]]).link)
-      .toBe(successfulCollectionRequest.payload.response[1].link);
-    });
+        const data = queryState.getIn([successfulCollectionRequest.payload.page, 'data']);
+        expect(queryState.get(successfulCollectionRequest.payload.page).toJSON())
+        .toInclude({
+          status: resolved,
+          error: false,
+          responseAt: successfulCollectionRequest.meta.responseAt,
+        });
 
-    it('should index even if there is no `id` nor customCacheIndexes in the response', () => {
-      const state = reducer(undefined, successfulOptionsRequest);
-      expect(state.getIn(['resources', 0]).blogname)
-      .toBe(successfulOptionsRequest.payload.response[0].blogname);
-    });
+        expect(data).toBeAn(Array);
+        expect(data.length).toBe(2);
 
-    it('mark as partial embedded resources', () => {
-      const state = reducer(undefined, successfulCollectionRequest);
-      const queryState = state.getIn([
-        'requestsByQuery',
-        successfulCollectionRequest.payload.cacheID,
-      ]);
-      const data = queryState.getIn([successfulCollectionRequest.payload.page, 'data']);
-      const resource = state.getIn(['resources', data[0]]);
-      const embeddedAuthor = state.getIn(['resources', resource._embedded.author]);
-      const parentNotPartial = state.getIn(['resources', resource._embedded.parent]);
+        const resource = state.getIn(['resources', data[0]]);
+        expect(resource[Symbols.lastCacheUpdate]).toBe(successfulCollectionRequest.meta.responseAt);
+        expect(resource[Symbols.partial]).toBe(false);
+      });
 
-      expect(embeddedAuthor[Symbols.partial]).toBe(true);
-      expect(parentNotPartial[Symbols.partial]).toBe(false);
-    });
+      it('should keep local ids instead objects in data, by query\'s cacheID', () => {
+        const state = reducer(undefined, successfulCollectionRequest);
+        const queryState = state.getIn([
+          'requestsByQuery',
+          successfulCollectionRequest.payload.cacheID,
+        ]);
+        const data = queryState.getIn([successfulCollectionRequest.payload.page, 'data']);
 
-    it('should persist locally each found resource exactly once', () => {
-      const state = reducer(undefined, successfulCollectionRequest);
-      const resources = state.get('resources');
-      expect(resources.size).toBe(4);
-      expect(resources.toJSON().map(item => item.link))
-      .toInclude(successfulCollectionRequest.payload.response[0]._embedded.author[0].link)
-      .toInclude(successfulCollectionRequest.payload.response[1].link)
-      .toInclude(successfulCollectionRequest.payload.response[1]._embedded.author[0].link)
-      .toInclude(successfulCollectionRequest.payload.response[0].link);
-    });
+        expect(data).toBeAn(Array);
+        expect(data.length).toBe(2);
+        expect(state.getIn(['resources', data[0]]).link)
+        .toBe(successfulCollectionRequest.payload.response[0].link);
 
-    it('should update previous resource\'s state', () => {
-      const previous = reducer(undefined, successfulCollectionRequest);
-      const state = reducer(previous, successfulQueryBySlug);
-      const queryState = state.getIn(['requestsByQuery', successfulQueryBySlug.payload.cacheID]);
-      const [id] = queryState.getIn([1, 'data']);
-      const resource = state.getIn(['resources', id]);
-      expect(resource).toContain({
-        [Symbols.lastCacheUpdate]: successfulQueryBySlug.meta.responseAt,
-        link: successfulQueryBySlug.payload.response[0].link,
+        expect(state.getIn(['resources', data[1]]).link)
+        .toBe(successfulCollectionRequest.payload.response[1].link);
+      });
+
+      it('should index resources by their aggregators and customCacheIndexes', () => {
+        const state = reducer(undefined, successfulCollectionRequest);
+        const queryState = state.getIn([
+          'requestsByQuery',
+          successfulCollectionRequest.payload.cacheID,
+        ]);
+
+        const data = queryState.getIn([successfulCollectionRequest.payload.page, 'data']);
+        const { response } = successfulCollectionRequest.payload;
+
+        response.forEach((resource, i) => {
+          expect(state.getIn(['resourcesIndexes', 'any', 'id', resource.id.toString()]))
+          .toBe(data[i]);
+          expect(state.getIn(['resourcesIndexes', 'any', 'slug', resource.slug]))
+          .toBe(data[i]);
+
+          const author = { ...resource._embedded.author[0] };
+          const authorUID = state.getIn(
+            ['resourcesIndexes', 'users', 'id', author.id.toString()]
+          );
+
+          delete author._embedded;
+          expect(state.getIn(['resources', authorUID])).toInclude(author);
+        });
+      });
+
+      it('should index even if there is no `id` nor customCacheIndexes in the response', () => {
+        const state = reducer(undefined, successfulOptionsRequest);
+        expect(state.getIn(['resources', 0]).blogname)
+        .toBe(successfulOptionsRequest.payload.response[0].blogname);
+      });
+
+      it('mark as partial embedded resources', () => {
+        const state = reducer(undefined, successfulCollectionRequest);
+        const queryState = state.getIn([
+          'requestsByQuery',
+          successfulCollectionRequest.payload.cacheID,
+        ]);
+        const data = queryState.getIn([successfulCollectionRequest.payload.page, 'data']);
+        const resource = state.getIn(['resources', data[0]]);
+        const embeddedAuthor = state.getIn(['resources', resource._embedded.author]);
+        const parentNotPartial = state.getIn(['resources', resource._embedded.parent]);
+
+        expect(embeddedAuthor[Symbols.partial]).toBe(true);
+        expect(parentNotPartial[Symbols.partial]).toBe(false);
+      });
+
+      it('should persist locally each found resource exactly once', () => {
+        const state = reducer(undefined, successfulCollectionRequest);
+        const resources = state.get('resources');
+        expect(resources.size).toBe(4);
+        expect(resources.toJSON().map(item => item.link))
+        .toInclude(successfulCollectionRequest.payload.response[0]._embedded.author[0].link)
+        .toInclude(successfulCollectionRequest.payload.response[1].link)
+        .toInclude(successfulCollectionRequest.payload.response[1]._embedded.author[0].link)
+        .toInclude(successfulCollectionRequest.payload.response[0].link);
+      });
+
+      it('should update previous resource\'s state', () => {
+        const previous = reducer(undefined, successfulCollectionRequest);
+        const state = reducer(previous, successfulQueryBySlug);
+        const queryState = state.getIn(['requestsByQuery', successfulQueryBySlug.payload.cacheID]);
+        const [id] = queryState.getIn([1, 'data']);
+        const resource = state.getIn(['resources', id]);
+        expect(resource).toContain({
+          [Symbols.lastCacheUpdate]: successfulQueryBySlug.meta.responseAt,
+          link: successfulQueryBySlug.payload.response[0].link,
+        });
       });
     });
-  });
 
-  describe('`REDUX_WP_API_FAILURE` action', () => {
-    describe('on get operation', () => {
-      it('should update state on query\'s cacheID status for GET operations', () => {
-        const state = reducer(undefined, unsuccessfulCollectionRequest);
-        expect(
-          state.getIn([
-            'requestsByQuery',
-            unsuccessfulCollectionRequest.payload.cacheID,
-            1,
-            'status',
-          ])
-        ).toBe(rejected);
-      });
-    });
-
-    modifyingOperations.forEach(type =>
-      describe(`on ${type} operation`, () => {
-        const response = {
-          ...unsuccessfulModifyingRequest,
-          meta: {
-            ...unsuccessfulModifyingRequest.meta,
-            operation: type,
-          },
-        };
-
-        it('should update status on request by name', () => {
-          const state = reducer(undefined, response);
+    describe('`REDUX_WP_API_FAILURE` action', () => {
+      describe('on get operation', () => {
+        it('should update state on query\'s cacheID status for GET operations', () => {
+          const state = reducer(undefined, unsuccessfulCollectionRequest);
           expect(
-            state.getIn(['requestsByName', response.meta.name, 'status'])
+            state.getIn([
+              'requestsByQuery',
+              unsuccessfulCollectionRequest.payload.cacheID,
+              1,
+              'status',
+            ])
           ).toBe(rejected);
         });
-      })
-    );
-  });
+      });
 
-  describe('`REDUX_WP_API_CACHE_HIT` action', () => {
-    it('should update state under request name', () => {
-      let previousState = reducer(undefined, collectionRequest);
-      previousState = reducer(previousState, successfulCollectionRequest);
-      const state = reducer(previousState, cacheHitSingle);
-      expect(state.getIn(['requestsByName', cacheHitSingle.meta.name]).toJSON())
-      .toInclude({
-        cacheID: cacheHitSingle.payload.cacheID,
-        page: cacheHitSingle.payload.page,
+      modifyingOperations.forEach(type =>
+        describe(`on ${type} operation`, () => {
+          const response = {
+            ...unsuccessfulModifyingRequest,
+            meta: {
+              ...unsuccessfulModifyingRequest.meta,
+              operation: type,
+            },
+          };
+
+          it('should update status on request by name', () => {
+            const state = reducer(undefined, response);
+            expect(
+              state.getIn(['requestsByName', response.meta.name, 'status'])
+            ).toBe(rejected);
+          });
+        })
+      );
+    });
+
+    describe('`REDUX_WP_API_CACHE_HIT` action', () => {
+      it('should update state under request name', () => {
+        let previousState = reducer(undefined, collectionRequest);
+        previousState = reducer(previousState, successfulCollectionRequest);
+        const state = reducer(previousState, cacheHitSingle);
+        expect(state.getIn(['requestsByName', cacheHitSingle.meta.name]).toJSON())
+        .toInclude({
+          cacheID: cacheHitSingle.payload.cacheID,
+          page: cacheHitSingle.payload.page,
+        });
+      });
+
+      it('should keep same query state', () => {
+        let previousState = reducer(undefined, collectionRequest);
+        previousState = reducer(previousState, successfulCollectionRequest);
+        const state = reducer(previousState, cacheHitCollection);
+        const { page, cacheID } = cacheHitCollection.payload;
+
+        expect(state.getIn(['requestsByQuery', cacheID, page]))
+        .toBe(previousState.getIn(['requestsByQuery', cacheID, page]));
+      });
+
+      it('should always have data as a Array under query\'s cacheID', () => {
+        let state = reducer(undefined, collectionRequest);
+        state = reducer(state, successfulCollectionRequest);
+        state = reducer(state, cacheHitSingle);
+        const { page, cacheID } = cacheHitSingle.payload;
+        expect(state.getIn(['requestsByQuery', cacheID, page, 'data'])).toBeAn('array');
+
+        state = reducer(state, cacheHitCollection);
+        const { page: collectionPage, cacheID: collectionUID } = cacheHitCollection.payload;
+
+        expect(state.getIn(['requestsByQuery', collectionUID, collectionPage, 'data']))
+        .toBeAn('array');
       });
     });
+  });
 
-    it('should keep same query state', () => {
-      let previousState = reducer(undefined, collectionRequest);
-      previousState = reducer(previousState, successfulCollectionRequest);
-      const state = reducer(previousState, cacheHitCollection);
-      const { page, cacheID } = cacheHitCollection.payload;
+  describe('with custom getAggregator setting', () => {
+    beforeEach(() => {
+      reducer = new ReduxWPAPI({
+        adapter: new AdapterMockForReducer(),
+        getAggregator(url, additionalData, suggestedAggregator) {
+          if (url.match(/\/search\/?/)) {
+            if (additionalData && additionalData._links && additionalData._links.self) {
+              return additionalData._links.self[0].href.replace(/.*\/(.*?)\/[^\/]*$/, '$1');
+            }
+          }
 
-      expect(state.getIn(['requestsByQuery', cacheID, page]))
-      .toBe(previousState.getIn(['requestsByQuery', cacheID, page]));
+          return suggestedAggregator;
+        },
+        customCacheIndexes: {
+          any: 'slug',
+        },
+      }).reducer;
     });
 
-    it('should always have data as a Array under query\'s cacheID', () => {
-      let state = reducer(undefined, collectionRequest);
-      state = reducer(state, successfulCollectionRequest);
-      state = reducer(state, cacheHitSingle);
-      const { page, cacheID } = cacheHitSingle.payload;
-      expect(state.getIn(['requestsByQuery', cacheID, page, 'data'])).toBeAn('array');
+    describe('`REDUX_WP_API_SUCCESS` action', () => {
+      it('should index resources by their aggregators and customCacheIndexes', () => {
+        const state = reducer(undefined, successfulSearchRequest);
+        const queryState = state.getIn([
+          'requestsByQuery',
+          successfulSearchRequest.payload.cacheID,
+        ]);
 
-      state = reducer(state, cacheHitCollection);
-      const { page: collectionPage, cacheID: collectionUID } = cacheHitCollection.payload;
+        const data = queryState.getIn([successfulSearchRequest.payload.page, 'data']);
+        const { response } = successfulSearchRequest.payload;
 
-      expect(state.getIn(['requestsByQuery', collectionUID, collectionPage, 'data']))
-      .toBeAn('array');
+        response.forEach((resource, i) => {
+          expect(state.getIn(['resourcesIndexes', 'any', 'id', resource.id.toString()]))
+          .toBe(data[i], `Any (id: ${resource.id}) was not indexed.`);
+          expect(state.getIn(['resourcesIndexes', 'any', 'slug', resource.slug]))
+          .toBe(data[i], `Any (slug: ${resource.slug}) was not indexed.`);
+
+          const author = { ...resource._embedded.author[0] };
+          const authorUID = state.getIn(
+            ['resourcesIndexes', 'users', 'id', author.id.toString()]
+          );
+
+          delete author._embedded;
+          expect(state.getIn(['resources', authorUID])).toInclude(author);
+        });
+      });
     });
   });
 });

--- a/test/reducer.spec.js
+++ b/test/reducer.spec.js
@@ -65,7 +65,7 @@ describe('Reducer', () => {
           .toBe(undefined, 'shouldnt touch data');
         });
 
-        it('should keep by request name the enought data to reach query', () => {
+        it('should have enough information in its request name to reach the query', () => {
           const state = reducer(undefined, collectionRequest);
           const nameState = state.getIn(['requestsByName', collectionRequest.meta.name]);
 
@@ -192,7 +192,7 @@ describe('Reducer', () => {
         .toBe(successfulOptionsRequest.payload.response[0].blogname);
       });
 
-      it('mark as partial embedded resources', () => {
+      it('should mark as partial embedded resources', () => {
         const state = reducer(undefined, successfulCollectionRequest);
         const queryState = state.getIn([
           'requestsByQuery',
@@ -207,7 +207,7 @@ describe('Reducer', () => {
         expect(parentNotPartial[Symbols.partial]).toBe(false);
       });
 
-      it('should persist locally each found resource exactly once', () => {
+      it('should persist locally, exactly once, each resource found', () => {
         const state = reducer(undefined, successfulCollectionRequest);
         const resources = state.get('resources');
         expect(resources.size).toBe(4);


### PR DESCRIPTION
Gives the ability of deciding resource aggregator per resource, for both the consumer or the adapter.

Resolves https://github.com/log-oscon/redux-wpapi/issues/22