### PR TITLE
Adapters TTL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ Some guidelines in reading this document:
 * Annotations starting with **[BC]** indicates breaking change.
 
 ## [new release]
-* FIX: TTL can be overriden.
+* Fix TTL behavior: It now can be overriden by the consumer when dispatching `callAPI` ([#24](https://github.com/log-oscon/redux-wpapi/pull/24))
 
 ## 1.3.0
 * ([#22](https://github.com/log-oscon/redux-wpapi/pull/22))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ Some guidelines in reading this document:
 * Being that these are the early days of the repository, we have some code changes that were added directly and without much detail, for these we have a link to the commit instead of the PR.
 * Annotations starting with **[BC]** indicates breaking change.
 
+## [new release]
+* FIX: TTL can be overriden.
+
 ## 1.3.0
 * ([#22](https://github.com/log-oscon/redux-wpapi/pull/22))
     * Adapter's `getAggregator` is now applied per resource and has `additionalData` in order decide, which might be either the query of the request or the resource itself.

--- a/src/ReduxWPAPI.js
+++ b/src/ReduxWPAPI.js
@@ -99,7 +99,7 @@ export default class ReduxWPAPI {
         ttl = this.adapter.getTTL(request);
       }
 
-      if (ttl !== 0 && !ttl) {
+      if (ttl !== 0 && ttl !== false && !ttl) {
         ttl = this.settings.ttl;
       }
 

--- a/src/ReduxWPAPI.js
+++ b/src/ReduxWPAPI.js
@@ -99,7 +99,7 @@ export default class ReduxWPAPI {
         ttl = this.adapter.getTTL(request);
       }
 
-      if (ttl !== 0 && ttl !== false && !ttl) {
+      if (ttl === null || ttl === undefined) {
         ttl = this.settings.ttl;
       }
 

--- a/src/adapters/wpapi.js
+++ b/src/adapters/wpapi.js
@@ -1,4 +1,5 @@
 import find from 'lodash/find';
+import isUndefined from 'lodash/isUndefined';
 import findKey from 'lodash/findKey';
 import reduce from 'lodash/reduce';
 import capitalize from 'lodash/capitalize';
@@ -259,7 +260,7 @@ export default class WPAPIAdapter {
    * @return {Number}         The time to live of request's resources
    */
   getTTL(request) {
-    return request.ttl || this.defaultTTL;
+    return isUndefined(request.ttl) || request.ttl === null ? this.defaultTTL : request.ttl;
   }
 
   /**

--- a/src/adapters/wpapi.js
+++ b/src/adapters/wpapi.js
@@ -1,5 +1,4 @@
 import find from 'lodash/find';
-import isUndefined from 'lodash/isUndefined';
 import findKey from 'lodash/findKey';
 import reduce from 'lodash/reduce';
 import capitalize from 'lodash/capitalize';
@@ -260,7 +259,7 @@ export default class WPAPIAdapter {
    * @return {Number}         The time to live of request's resources
    */
   getTTL(request) {
-    return isUndefined(request.ttl) || request.ttl === null ? this.defaultTTL : request.ttl;
+    return request.ttl === undefined || request.ttl === null ? this.defaultTTL : request.ttl;
   }
 
   /**


### PR DESCRIPTION
`wpapi` adapter's TTL should allow TTL request to be `false` or `0` so the request will be done even with local Cache.