### PR TITLE
Ensures pagination shape and presence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ Some guidelines in reading this document:
 * Being that these are the early days of the repository, we have some code changes that were added directly and without much detail, for these we have a link to the commit instead of the PR.
 * Annotations starting with **[BC]** indicates breaking change.
 
+## [new release]
+* Fix: Ensures pagination shape and presence in response. ([#25](https://github.com/log-oscon/redux-wpapi/pull/25))
+
 ## 1.3.0
 * ([#22](https://github.com/log-oscon/redux-wpapi/pull/22))
     * Adapter's `getAggregator` is now applied per resource and has `additionalData` in order decide, which might be either the query of the request or the resource itself.

--- a/src/ReduxWPAPI.js
+++ b/src/ReduxWPAPI.js
@@ -217,6 +217,18 @@ export default class ReduxWPAPI {
           );
         }
 
+        if (!newState.getIn(['requestsByQuery', cacheID, 'pagination'])) {
+          newState = (
+            newState
+            .mergeIn(
+              ['requestsByQuery', cacheID, 'pagination'],
+              {
+                total: 1,
+                totalPages: 1,
+              }
+            )
+          );
+        }
 
         return newState;
       }

--- a/src/adapters/wpapi.js
+++ b/src/adapters/wpapi.js
@@ -83,16 +83,16 @@ export default class WPAPIAdapter {
   /**
    * Extracts pagination params from Response
    *
-   * It is up to the api decide the shape of pagination, `totalPages` and `total` are a common case.
+   * Pagination requires `totalPages` and `total`.
    *
    * @param {Object|Array} response Response resulted by `callAPI` operation
-   * @return {Object}               Pagination params such as `total` and `totalPages`
+   * @return {Object}               Pagination composed by `total` and `totalPages`.
    */
   getPagination(response) {
     const { total, totalPages } = response._paging || {};
     return {
-      total: parseInt(total || 1, 10),
-      totalPages: parseInt(totalPages || 1, 10),
+      total: parseInt(total || 0, 10),
+      totalPages: parseInt(totalPages || 0, 10),
     };
   }
 


### PR DESCRIPTION
When there was a CACHE_HIT for a single resource originated by a collection request, CACHE_HIT wouldn't ensure the pagination attribute, but now it does and for that, the shape of pagination is defined by `total` and `totalPages`.